### PR TITLE
updated library name from `qjson` to `qjson-qt5`.

### DIFF
--- a/JSONToMySQL/jsontomysql.pro
+++ b/JSONToMySQL/jsontomysql.pro
@@ -15,7 +15,7 @@ CONFIG   -= app_bundle
 TEMPLATE = app
 
 unix:INCLUDEPATH += /usr/include ../3rdparty
-unix:LIBS += -L/usr/lib64 -l qjson
+unix:LIBS += -L/usr/lib64 -l qjson-qt5
 
 SOURCES += main.cpp \
     insertvalues.cpp


### PR DESCRIPTION
This fixes a compile error due to inability to find library "qjson" in recent build.

This is due to an update in qjson code to allow for simultaneous installs of qt4 and qt5. (Or something like that - I think [this commit?](https://github.com/flavio/qjson/commit/1295e1bbca68c9dd73719436319324a75d9a68a1) is the issue?
