### PR TITLE
Update include path to match new library name

### DIFF
--- a/JSONToMySQL/main.cpp
+++ b/JSONToMySQL/main.cpp
@@ -19,7 +19,7 @@ License along with ODKTools.  If not, see <http://www.gnu.org/licenses/lgpl-3.0.
 */
 
 #include <QCoreApplication>
-#include <qjson/parser.h>
+#include <qjson-qt5/parser.h>
 #include <tclap/CmdLine.h>
 #include <QSqlDatabase>
 #include <QSqlError>


### PR DESCRIPTION
Extra fix for updating qjson library to new name "qjson-qt5"
